### PR TITLE
Ubah respons login jadi token dan data pengguna

### DIFF
--- a/internal/handler/http/router.go
+++ b/internal/handler/http/router.go
@@ -57,7 +57,7 @@ func SetupRouter(
 			authRoutes.GET("/search/users", searchHandler.SearchUsers)
 
 			// User profile and wallet routes
-			authRoutes.GET("/users/:username", userHandler.GetUserProfile)
+			authRoutes.GET("/users/profile", userHandler.GetUserProfile)
 			authRoutes.PATCH("/users/me", userHandler.UpdateProfile)
 			authRoutes.POST("/wallet/unlock", userHandler.UnlockWallet)
 			authRoutes.POST("/wallet/export", userHandler.ExportPrivateKey)

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -16,6 +16,7 @@ type UserRepository interface {
 	FindByID(ctx context.Context, id primitive.ObjectID) (*domain.User, error)
 	FindByEmail(ctx context.Context, email string) (*domain.User, error)
 	FindByUsername(ctx context.Context, username string) (*domain.User, error)
+	FindByVID(ctx context.Context, vid int64) (*domain.User, error)
 	FindManyByIDs(ctx context.Context, ids []primitive.ObjectID) ([]domain.User, error)
 	SearchUsers(ctx context.Context, query string, limit int) ([]domain.User, error)
 	Update(ctx context.Context, user *domain.User) error
@@ -68,6 +69,18 @@ func (r *mongoUserRepository) FindByEmail(ctx context.Context, email string) (*d
 func (r *mongoUserRepository) FindByUsername(ctx context.Context, username string) (*domain.User, error) {
 	var user domain.User
 	err := r.db.Collection(r.collection).FindOne(ctx, bson.M{"username": username}).Decode(&user)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &user, nil
+}
+
+func (r *mongoUserRepository) FindByVID(ctx context.Context, vid int64) (*domain.User, error) {
+	var user domain.User
+	err := r.db.Collection(r.collection).FindOne(ctx, bson.M{"vid": vid}).Decode(&user)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -35,10 +35,15 @@ type UserProfileResponse struct {
 	FriendshipStatus string `json:"friendshipStatus"`
 }
 
+type UserMinimal struct {
+	VID      int64  `json:"vid"`
+	Username string `json:"username"`
+}
+
 type LoginResponse struct {
-	AccessToken  string     `json:"access_token"`
-	RefreshToken string     `json:"refresh_token"`
-	UserData     *domain.User `json:"user_data"`
+	AccessToken  string      `json:"access_token"`
+	RefreshToken string      `json:"refresh_token"`
+	UserData     *UserMinimal `json:"user_data"`
 }
 
 // UserService defines the interface for user business logic.
@@ -155,7 +160,7 @@ func (s *userService) Login(ctx context.Context, email, password, userAgent, cli
 	return &LoginResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
-		UserData:     user,
+		UserData:     &UserMinimal{VID: user.VID, Username: user.Username},
 	}, nil
 }
 
@@ -188,7 +193,7 @@ func (s *userService) RefreshToken(ctx context.Context, refreshToken string) (*L
 	return &LoginResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
-		UserData:     user,
+		UserData:     &UserMinimal{VID: user.VID, Username: user.Username},
 	}, nil
 }
 

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -36,8 +36,9 @@ type UserProfileResponse struct {
 }
 
 type LoginResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
+	AccessToken  string     `json:"access_token"`
+	RefreshToken string     `json:"refresh_token"`
+	UserData     *domain.User `json:"user_data"`
 }
 
 // UserService defines the interface for user business logic.
@@ -154,6 +155,7 @@ func (s *userService) Login(ctx context.Context, email, password, userAgent, cli
 	return &LoginResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
+		UserData:     user,
 	}, nil
 }
 
@@ -186,6 +188,7 @@ func (s *userService) RefreshToken(ctx context.Context, refreshToken string) (*L
 	return &LoginResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
+		UserData:     user,
 	}, nil
 }
 

--- a/test_login_response.go
+++ b/test_login_response.go
@@ -3,35 +3,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"vybes/internal/domain"
 	"vybes/internal/service"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func main() {
-	// Example of the new LoginResponse structure
-	userID, _ := primitive.ObjectIDFromHex("507f1f77bcf86cd799439011")
-	user := &domain.User{
-		ID:            userID,
-		VID:           12345,
-		Name:          "John Doe",
-		Email:         "john@example.com",
-		Username:      "johndoe",
-		PFPURL:        "https://example.com/pfp.jpg",
-		BannerURL:     "https://example.com/banner.jpg",
-		Bio:           "Hello, I'm John!",
-		WalletAddress: "0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6",
-		TotalLikeCount: 100,
-		PostCount:     50,
-	}
-
 	loginResponse := &service.LoginResponse{
 		AccessToken:  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
 		RefreshToken: "abc123def456ghi789jkl012mno345pqr678stu901vwx234yz",
-		UserData:     user,
+		UserData:     &service.UserMinimal{VID: 12345, Username: "johndoe"},
 	}
 
-	// Convert to JSON to show the structure
 	jsonData, err := json.MarshalIndent(loginResponse, "", "  ")
 	if err != nil {
 		fmt.Printf("Error marshaling JSON: %v\n", err)

--- a/test_login_response.go
+++ b/test_login_response.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"vybes/internal/domain"
+	"vybes/internal/service"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func main() {
+	// Example of the new LoginResponse structure
+	userID, _ := primitive.ObjectIDFromHex("507f1f77bcf86cd799439011")
+	user := &domain.User{
+		ID:            userID,
+		VID:           12345,
+		Name:          "John Doe",
+		Email:         "john@example.com",
+		Username:      "johndoe",
+		PFPURL:        "https://example.com/pfp.jpg",
+		BannerURL:     "https://example.com/banner.jpg",
+		Bio:           "Hello, I'm John!",
+		WalletAddress: "0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6",
+		TotalLikeCount: 100,
+		PostCount:     50,
+	}
+
+	loginResponse := &service.LoginResponse{
+		AccessToken:  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+		RefreshToken: "abc123def456ghi789jkl012mno345pqr678stu901vwx234yz",
+		UserData:     user,
+	}
+
+	// Convert to JSON to show the structure
+	jsonData, err := json.MarshalIndent(loginResponse, "", "  ")
+	if err != nil {
+		fmt.Printf("Error marshaling JSON: %v\n", err)
+		return
+	}
+
+	fmt.Println("New Login Response Structure:")
+	fmt.Println(string(jsonData))
+}


### PR DESCRIPTION
Add minimal user data to login response and enable user profile lookup by VID or username.

The `GetUserProfile` endpoint was refactored to support lookup by `vid` or `username` query parameters, which involved adding `FindByVID` to the repository and updating the service logic. As part of this refactoring, the caching mechanism for user profiles was removed from the service layer.